### PR TITLE
fix the crash due to wrong reflect type usage

### DIFF
--- a/table/generic.go
+++ b/table/generic.go
@@ -27,7 +27,7 @@ func (t *Table[K, E]) Initialize(col db.StoreCollection) error {
 		return errors.Wrapf(errors.AlreadyExists, "Table is already initialized")
 	}
 	var key [0]K
-	kType := reflect.TypeOf(key)
+	kType := reflect.TypeOf(key).Elem()
 	if kType.Kind() != reflect.Pointer {
 		kType = reflect.PointerTo(kType)
 	}


### PR DESCRIPTION
it requires to use the type of elem instead of the slice itself fix crash trace like
goroutine 115 [running]:
log.Panicf({0x9aa7f4?, 0x0?}, {0xc000507e48?, 0xd95210?, 0x0?})
        /usr/local/go/src/log/log.go:439 +0x65
github.com/Prabhjot-Sethi/core/db.(*mongoCollection).Watch.func1.2()
        /home/core/go/pkg/mod/github.com/!prabhjot-!sethi/core@v0.0.0-20250504230306-35d0b36d9034/db/mongo.go:247 +0x7d
github.com/Prabhjot-Sethi/core/db.(*mongoCollection).Watch.func1()
        /home/core/go/pkg/mod/github.com/!prabhjot-!sethi/core@v0.0.0-20250504230306-35d0b36d9034/db/mongo.go:299 +0x3c2
created by github.com/Prabhjot-Sethi/core/db.(*mongoCollection).Watch in goroutine 1
        /home/core/go/pkg/mod/github.com/!prabhjot-!sethi/core@v0.0.0-20250504230306-35d0b36d9034/db/mongo.go:232 +0x158